### PR TITLE
dropping motd rewrite at each autologin

### DIFF
--- a/sabayon-functions.sh
+++ b/sabayon-functions.sh
@@ -140,10 +140,6 @@ sabayon_setup_live_user() {
     return 1
 }
 
-sabayon_setup_motd() {
-    echo -e "\n\tWelcome to `cat /etc/sabayon-edition`\n\t`uname -p`\n\t`uname -o` `uname -r`\n" > /etc/motd
-}
-
 sabayon_setup_vt_autologin() {
     if openrc_running; then
         . /sbin/livecd-functions.sh

--- a/sabayonlive.sh
+++ b/sabayonlive.sh
@@ -150,7 +150,6 @@ main() {
     # /etc/profile.env variables
     setup_locale
     sabayon_setup_autologin
-    sabayon_setup_motd
     sabayon_setup_vt_autologin
     sabayon_setup_oem_livecd
 }


### PR DESCRIPTION
the motd rewrite now results in an annoying pop-up and slowdown in KDE boot and when this also happens when reloading session in GNOME from live-cd
